### PR TITLE
fix a missing rename

### DIFF
--- a/aquifer/__init__.py
+++ b/aquifer/__init__.py
@@ -1,3 +1,3 @@
 from .core import Metrics
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/aquifer/core.py
+++ b/aquifer/core.py
@@ -4,7 +4,7 @@ class Metrics(object):
     def __init__(self, metrics_uri):
         import urlparse
 
-        from metrics.backends import get_backend
+        from aquifer.backends import get_backend
         # parse the uri
         parsed_metrics_url = urlparse.urlparse(metrics_uri)
 


### PR DESCRIPTION
I think the test passed on my machine because I have something either locally cached as `.pyc` or I have a globally installed pip module from previous tests.. 

@paulmelnikow Can you turn on CircleCI for this repo? it seems still not added.
