### PR TITLE
add hostname support

### DIFF
--- a/aquifer/__init__.py
+++ b/aquifer/__init__.py
@@ -1,3 +1,3 @@
 from .core import Metrics
 
-__version__ = '1.0.2'
+__version__ = '1.1.0'

--- a/aquifer/backends/datadog_backend.py
+++ b/aquifer/backends/datadog_backend.py
@@ -2,11 +2,11 @@ import time
 
 class Datadog(object):
 
-    def __init__(self, auth, app_key=None, **options):
+    def __init__(self, auth, app_key=None, host=None, **options):
         import datadog
 
         # datadog we use username in auth as api_key
-        datadog.initialize(api_key=auth['username'], app_key=app_key, **options)
+        datadog.initialize(api_key=auth['username'], app_key=app_key, host_name=host, **options)
 
         self.client = datadog.api
 

--- a/aquifer/core.py
+++ b/aquifer/core.py
@@ -1,7 +1,7 @@
 class Metrics(object):
     """A metrics client, which locates its backend from the URI
     """
-    def __init__(self, metrics_uri):
+    def __init__(self, metrics_uri, host=None):
         import urlparse
 
         from aquifer.backends import get_backend
@@ -28,7 +28,7 @@ class Metrics(object):
 
         backend_cls = get_backend(parsed_metrics_url.hostname)
 
-        self.backend = backend_cls(auth=auth, **options)
+        self.backend = backend_cls(auth=auth, host=host, **options)
 
     # send a metric
     def send(self, name, value, metrics_type='gauge', tags=None, timestamp=None):

--- a/aquifer/test_core.py
+++ b/aquifer/test_core.py
@@ -11,9 +11,9 @@ class TestCore(unittest.TestCase):
         _ = initialize_mock # For pylint.
         metrics_uri = 'metrics://abc@datadog?app_key=def&debug=true'
 
-        Metrics(metrics_uri)
+        Metrics(metrics_uri, host='i-12345')
 
-        initialize_mock.assert_called_once_with(api_key='abc', app_key='def', debug='true')
+        initialize_mock.assert_called_once_with(api_key='abc', app_key='def', host_name='i-12345', debug='true')
 
     @mock.patch('datadog.initialize')
     def test_metrics_initialized_with_unknown_backend_raise_error(self, initialize_mock):


### PR DESCRIPTION
to enabled some hostmap graph like [this](https://app.datadoghq.com/dash/129235/cluster-health?live=true)

Datadog's other AWS integration could correlate the host name with the metrics we send, so this seems to be a good thing to turn on.
